### PR TITLE
Added interval functionality

### DIFF
--- a/client/src/components/config/createUser.jsx
+++ b/client/src/components/config/createUser.jsx
@@ -36,11 +36,11 @@ class CreateUserDialog extends Component {
           <Form onSubmit={this.handleSubmit}>
             <Form.Field>
               <label>Username</label>
-              <Input fluid icon='Add User' iconPosition='left' placeholder='Username' name='username' onChange={this.handleChange} />
+              <Input fluid icon='add user' iconPosition='left' placeholder='Username' name='username' onChange={this.handleChange} />
             </Form.Field>
             <Form.Field>
               <label>Password</label>
-              <Input fluid icon='Lock' iconPosition='left' placeholder='Password' name='password' onChange={this.handleChange} />
+              <Input fluid icon='lock' iconPosition='left' placeholder='Password' name='password' onChange={this.handleChange} />
             </Form.Field>
             <Divider />
             <Button fluid color='green' type='submit'>Register</Button>

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "prestart": "pgrep mongod || mongod --dbpath db/data --fork --logpath db/logs/mongodb.log",
+    "prestart": "pgrep mongod || (mkdir -p db/data && mkdir -p db/logs && mongod --dbpath db/data --fork --logpath db/logs/mongodb.log)",
     "start": "nodemon server/server.js",
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "webpack --colors -w"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "prestart": "pgrep mongod || mongod --dbpath db/data --fork --logpath db/logs/mongodb.log",
     "start": "nodemon server/server.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "webpack --colors -w"
   },
   "repository": {
     "type": "git",

--- a/server/crawler/crawler.js
+++ b/server/crawler/crawler.js
@@ -5,75 +5,72 @@ const Crawler = require('./crawlerModel.js');
 for Cheerio selectors. Document is created using data array, and saved to the Crawler model. */
 
 // *** represents items that will be provided by the config file
-class NCrawler {
-  constructor() {
-    this.c = new NodeCrawler({
-      maxConnections: 10,
-      callback: this.callback,
-    });
-    this.data = [];
+
+module.exports = (url) => {
+  // Instantiate the crawler
+  c = new NodeCrawler({
+    maxConnections: 10,
+    callback: this.callback,
+  });
+  
+  // Callback function runs when 
+  const callback = (error, res, done) => {
+    console.log('Starting scrape');
+    if (error) console.log(error);
+    else {
+      const $ = res.$;
+
+      extractData = async () => {
+        try {
+          // *** Selectors for DOM elements
+          await $('.cardDetails').each((index, element) => {
+            console.log(data);
+            data.push($(element).text());
+          });
+
+          // Support for Pagination
+          let href = $('[aria-label="Next page"]').attr('href');
+          // If href exists, scrape next page
+          if (href) c.queue('https:' + href);
+          // At end of pagination, add/update document
+          else {
+            let scrapedData = new Crawler({
+              // *** Endpoint Name
+              endpoint: "config",
+              data: JSON.stringify(data)
+            })
+
+            // Replace existing data property if the document exists
+            const cachedData = (await Crawler.find({endpoint: "config"}));
+            if (cachedData.length > 0) {
+              await Crawler.update({endpoint: 'config'}, { $set: { 
+                data: JSON.stringify(data),
+                scrape_date: Date.now(),
+              }});
+              console.log('Updated existing scraped data')
+            }
+            // Create a new document if scraping for the first time
+            else {
+              await scrapedData.save();
+              console.log('Saved new scraped data')
+            }
+          }
+        } catch (err) {
+          console.log(err);
+        }
+      }
+
+      extractData();
+      console.log('datalength:', data.length);
+    };
+    done();
   }
   
-}
+  // Data store for paginated scrape
+  data = [];
   
-NCrawler.prototype.callback = function (error, res, done) {
-  console.log('starting scrape')
-  const c = this.c;
-  const data = this.data;
-  console.log('this', this);
+  console.log('url', url);
+  console.log(c);
   
-  if (error) console.log(error);
-  else {
-    const $ = res.$;
-
-    extractData = async () => {
-      try {
-        // *** Selectors for DOM elements
-        await $('.cardDetails').each((index, element) => {
-          console.log(data);
-          data.push($(element).text());
-        });
-
-        // Support for Pagination
-        let href = $('[aria-label="Next page"]').attr('href');
-        // If href exists, scrape next page
-        if (href) c.queue('https:' + href);
-        // At end of pagination, add/update document
-        else {
-          let scrapedData = new Crawler({
-            // *** Endpoint Name
-            endpoint: "config",
-            data: JSON.stringify(data)
-          })
-
-          // Replace existing data property if the document exists
-          const cachedData = (await Crawler.find({endpoint: "config"}));
-          if (cachedData.length > 0) {
-            await Crawler.update({endpoint: 'config'}, { $set: { 
-              data: JSON.stringify(data),
-              scrape_date: Date.now(),
-            }});
-            console.log('Updated existing scraped data')
-          }
-          // Create a new document if scraping for the first time
-          else {
-            await scrapedData.save();
-            console.log('Saved new scraped data')
-          }
-        }
-      } catch (err) {
-        console.log(err);
-      }
-    }
-
-    extractData();
-    console.log('datalength:', data.length);
-  };
-  done();
+  c.queue(url);
 }
-
-// REMOVED by Brett -- this now exports c itself, so queue can be called in another file. We'll probably have to further modularize this file so it can get more info from the config file (stuff with ***'s)
-// *** url from config file is passed to queue
-//c.queue('https://www.trulia.com/CA/San_Francisco/');
-
-module.exports = NCrawler;

--- a/server/crawler/crawler.js
+++ b/server/crawler/crawler.js
@@ -6,71 +6,63 @@ for Cheerio selectors. Document is created using data array, and saved to the Cr
 
 // *** represents items that will be provided by the config file
 
-module.exports = (url) => {
-  // Instantiate the crawler
-  c = new NodeCrawler({
+module.exports = (url, endpointName) => {
+  let data = [];
+
+  const c = new NodeCrawler({
     maxConnections: 10,
-    callback: this.callback,
-  });
-  
-  // Callback function runs when 
-  const callback = (error, res, done) => {
-    console.log('Starting scrape');
-    if (error) console.log(error);
-    else {
-      const $ = res.$;
-
-      extractData = async () => {
-        try {
-          // *** Selectors for DOM elements
-          await $('.cardDetails').each((index, element) => {
-            console.log(data);
-            data.push($(element).text());
-          });
-
-          // Support for Pagination
-          let href = $('[aria-label="Next page"]').attr('href');
-          // If href exists, scrape next page
-          if (href) c.queue('https:' + href);
-          // At end of pagination, add/update document
-          else {
-            let scrapedData = new Crawler({
-              // *** Endpoint Name
-              endpoint: "config",
-              data: JSON.stringify(data)
-            })
-
-            // Replace existing data property if the document exists
-            const cachedData = (await Crawler.find({endpoint: "config"}));
-            if (cachedData.length > 0) {
-              await Crawler.update({endpoint: 'config'}, { $set: { 
-                data: JSON.stringify(data),
-                scrape_date: Date.now(),
-              }});
-              console.log('Updated existing scraped data')
-            }
-            // Create a new document if scraping for the first time
+    callback: (error, res, done) => {
+      console.log(`Processing page scrape for ${endpointName}`);
+      if (error) console.log(error);
+      else {
+        const $ = res.$;
+        async function extractData() {
+          try {
+            // *** Selectors for DOM elements
+            await $('.cardDetails').each((index, element) => {
+                data.push($(element).text());
+            });
+            // Support for Pagination
+            let href = $('[aria-label="Next page"]').attr('href');
+            // If href exists, scrape next page
+            if (href) c.queue('https:' + href);
+            // At end of pagination, add/update document
             else {
-              await scrapedData.save();
-              console.log('Saved new scraped data')
+              let scrapedData = new Crawler({
+                // *** Endpoint Name
+                endpoint: endpointName,
+                data: JSON.stringify(data)
+              })
+              // Replace existing data property if the document exists
+              const cachedData = (await Crawler.find({endpoint: endpointName}));
+              if (cachedData.length > 0) {
+                await Crawler.update({
+                  endpoint: endpointName
+                }, 
+                { 
+                  $set: { 
+                    data: JSON.stringify(data),
+                    scrape_date: Date.now(),
+                  }
+                });
+              } 
+              
+              // Create a new document if scraping for the first time
+              else {
+                await scrapedData.save();
+              }
             }
+          } catch (err) {
+            console.log(err);
           }
-        } catch (err) {
-          console.log(err);
         }
-      }
+        extractData();
+        console.log('datalength:', data.length);
+      };
+      done();
+    }
+  });
 
-      extractData();
-      console.log('datalength:', data.length);
-    };
-    done();
-  }
-  
-  // Data store for paginated scrape
-  data = [];
-  
-  console.log('url', url);
-  console.log(c);
-  
+  // *** url from config file is passed to queue
   c.queue(url);
 }

--- a/server/crawler/crawler.js
+++ b/server/crawler/crawler.js
@@ -5,51 +5,75 @@ const Crawler = require('./crawlerModel.js');
 for Cheerio selectors. Document is created using data array, and saved to the Crawler model. */
 
 // *** represents items that will be provided by the config file
+class NCrawler {
+  constructor() {
+    this.c = new NodeCrawler({
+      maxConnections: 10,
+      callback: this.callback,
+    });
+    this.data = [];
+  }
+  
+}
+  
+NCrawler.prototype.callback = function (error, res, done) {
+  console.log('starting scrape')
+  const c = this.c;
+  const data = this.data;
+  console.log('this', this);
+  
+  if (error) console.log(error);
+  else {
+    const $ = res.$;
 
-let data = [];
+    extractData = async () => {
+      try {
+        // *** Selectors for DOM elements
+        await $('.cardDetails').each((index, element) => {
+          console.log(data);
+          data.push($(element).text());
+        });
 
-const c = new NodeCrawler({
-    maxConnections: 10,
-    callback: (error, res, done) => {
-        if (error) console.log(error);
+        // Support for Pagination
+        let href = $('[aria-label="Next page"]').attr('href');
+        // If href exists, scrape next page
+        if (href) c.queue('https:' + href);
+        // At end of pagination, add/update document
         else {
-            const $ = res.$;
-            async function extractData() {
-                try {
-                    // *** Selectors for DOM elements
-                    await $('.cardDetails').each((index, element) => {
-                        data.push($(element).text());
-                    });
-                    // Support for Pagination
-                    let href = $('[aria-label="Next page"]').attr('href');
-                    // If href exists, scrape next page
-                    if (href) c.queue('https:' + href);
-                    // At end of pagination, add/update document
-                    else {
-                        let scrapedData = new Crawler({
-                            // *** Endpoint Name
-                            endpoint: "config",
-                            data: JSON.stringify(data)
-                        })
-                        // Replace existing data property if the document exists
-                        const cachedData = (await Crawler.find({endpoint: "config"}));
-                        if (cachedData.length > 0) {
-                            await Crawler.update({endpoint: 'config'}, { $set: { data: JSON.stringify(data) }});
-                        // Create a new document if scraping for the first time
-                        } else {
-                            await scrapedData.save();
-                        }
-                    }
-                    console.log(await Crawler.find({}));
-                } catch (err) {
-                    console.log(err);
-                }
-            }
-            extractData();
-        };
-        done();
-    }
-});
+          let scrapedData = new Crawler({
+            // *** Endpoint Name
+            endpoint: "config",
+            data: JSON.stringify(data)
+          })
 
+          // Replace existing data property if the document exists
+          const cachedData = (await Crawler.find({endpoint: "config"}));
+          if (cachedData.length > 0) {
+            await Crawler.update({endpoint: 'config'}, { $set: { 
+              data: JSON.stringify(data),
+              scrape_date: Date.now(),
+            }});
+            console.log('Updated existing scraped data')
+          }
+          // Create a new document if scraping for the first time
+          else {
+            await scrapedData.save();
+            console.log('Saved new scraped data')
+          }
+        }
+      } catch (err) {
+        console.log(err);
+      }
+    }
+
+    extractData();
+    console.log('datalength:', data.length);
+  };
+  done();
+}
+
+// REMOVED by Brett -- this now exports c itself, so queue can be called in another file. We'll probably have to further modularize this file so it can get more info from the config file (stuff with ***'s)
 // *** url from config file is passed to queue
-c.queue('https://www.trulia.com/CA/San_Francisco/');
+//c.queue('https://www.trulia.com/CA/San_Francisco/');
+
+module.exports = NCrawler;

--- a/server/crawler/crawlerController.js
+++ b/server/crawler/crawlerController.js
@@ -1,16 +1,38 @@
 const Crawler = require('./crawlerModel.js');
+const NodeCrawler = require('./crawler.js');
+
+// Object containing intervals, so they can be paused or terminated
+// Key is the name of the endpoint/scrape
+// Value is the timer object returned when the interval is set
+const intervals = {};
 
 const crawlerController = {
-    getCache: async (req, res) => {
-        try {
-            const config = req.query.config;
-            // Send document back as JSON object
-            res.json(await Crawler.find({"config": config}));
-        } catch (err) {
-            console.log (err);
-        }
-        next();
+  getCache: async (req, res) => {
+    try {
+      const config = req.query.config;
+      // Send document back as JSON object
+      res.json(await Crawler.find({"config": config}));
+    } catch (err) {
+      console.log (err);
     }
+    next();
+  },
+  
+  // Sets up a scrape to run on an interval
+  startScrapeInterval: (endpoint, interval) => {
+    // If the endpoint already has an interval
+      // Stop the interval
+    if (intervals[endpoint]) clearInterval(intervals[endpoint]);
+    
+    // Create a new interval
+    const c = new NodeCrawler();
+    intervals[endpoint] = setInterval(
+      () => c.c.queue('https://www.trulia.com/CA/San_Francisco/'),
+      interval
+    );
+    
+    console.log(intervals);
+  }
 }
 
 module.exports = crawlerController;

--- a/server/crawler/crawlerController.js
+++ b/server/crawler/crawlerController.js
@@ -26,7 +26,7 @@ const crawlerController = {
     
     // Create a new interval
     intervals[endpoint] = setInterval(
-      () => NodeCrawler('https://www.trulia.com/CA/San_Francisco/'),
+      () => NodeCrawler('https://www.trulia.com/CA/San_Francisco/', endpoint),
       interval
     );
   }

--- a/server/crawler/crawlerController.js
+++ b/server/crawler/crawlerController.js
@@ -19,6 +19,7 @@ const crawlerController = {
   },
   
   // Sets up a scrape to run on an interval
+  // Currently scrapes trulia only
   startScrapeInterval: (endpoint, interval) => {
     // If the endpoint already has an interval
       // Stop the interval

--- a/server/crawler/crawlerController.js
+++ b/server/crawler/crawlerController.js
@@ -25,13 +25,10 @@ const crawlerController = {
     if (intervals[endpoint]) clearInterval(intervals[endpoint]);
     
     // Create a new interval
-    const c = new NodeCrawler();
     intervals[endpoint] = setInterval(
-      () => c.c.queue('https://www.trulia.com/CA/San_Francisco/'),
+      () => NodeCrawler('https://www.trulia.com/CA/San_Francisco/'),
       interval
     );
-    
-    console.log(intervals);
   }
 }
 

--- a/server/crawler/crawlerModel.js
+++ b/server/crawler/crawlerModel.js
@@ -12,7 +12,6 @@ const crawlerSchema = new Schema({
   endpoint: {type: String, required: true}, // config file
   scrape_date: {type: Date, default: Date.now(), required: true},
   data: {type: Object, required: true}, // crawler
-  interval: {type: Number, default: INTERVAL, required: true}, // Amount of time between scrapes, in seconds
 });
 
 module.exports = mongoose.model("Crawler", crawlerSchema);

--- a/server/server.js
+++ b/server/server.js
@@ -38,3 +38,5 @@ app.post('/config/admin',
 app.listen(PORT, () => {
     console.log(`App is listening on Port ${PORT}`);
 });
+
+crawlerController.startScrapeInterval('pizza', 10000);

--- a/server/server.js
+++ b/server/server.js
@@ -25,7 +25,7 @@ app.get('/config',
   }
 );
 
-app.get('endpoint', crawlerController.getCache);
+app.get('/endpoint', crawlerController.getCache);
 
 app.post('/config/admin', 
   userController.checkFirstUser,

--- a/server/server.js
+++ b/server/server.js
@@ -39,4 +39,5 @@ app.listen(PORT, () => {
     console.log(`App is listening on Port ${PORT}`);
 });
 
-crawlerController.startScrapeInterval('pizza', 10000);
+// Demo interval scrape
+//crawlerController.startScrapeInterval('pizza', 10000);


### PR DESCRIPTION
crawlerController.startScrapeInterval is a method that starts a scrape on an interval. When one scrape finishes, it overwrites the existing data. An example of this is commented out on server.js.

Also: 
* Updated createUser.jsx to use the correct icon names and remove a client-side warning from SemanticUI
* Added `npm run build` which starts webpack in watch mode
* Updated `npm prestart` to create the db/logs and db/data folders if they don't exist