### PR TITLE
Added https support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,5 +63,8 @@ db/
 # Build files
 client/public/bundles
 
+# SSL Keys
+ssl/
+
 # Hidden file for installation script to know which version is installed
 .LAS_status

--- a/server/server.js
+++ b/server/server.js
@@ -1,4 +1,7 @@
 const express = require('express');
+const http = require('http');
+const https = require('https');
+const fs = require('fs')
 const pug = require('pug');
 const path = require('path');
 const bodyParser = require('body-parser');
@@ -9,7 +12,6 @@ const endpointController = require('./endpoint/endpointController.js');
 const sessionController = require('./session/sessionController.js');
 
 const app = express();
-const PORT = 4000;
 
 app.set('view engine', 'pug');
 app.set('views', path.join(__dirname, '../client/views'));
@@ -67,9 +69,24 @@ app.post('/crawls',
 );
 
 
-app.listen(PORT, () => {
-    console.log(`App is listening on Port ${PORT}`);
-});
+// ----------------------
+// HTTPS Config
+// ----------------------
+
+const privateKey  = fs.readFileSync('ssl/key.pem', 'utf8');
+const certificate = fs.readFileSync('ssl/cert.pem', 'utf8');
+const credentials = {key: privateKey, cert: certificate};
+const httpServer = http.createServer(app);
+const httpsServer = https.createServer(credentials, app);
+const HTTP_PORT = 4000;
+const HTTPS_PORT = 4443;
+
+httpServer.listen(HTTP_PORT, () => console.log(`HTTP on port ${HTTP_PORT}`));
+httpsServer.listen(HTTPS_PORT, () => console.log(`HTTPS on port ${HTTPS_PORT}`));
+
+//app.listen(PORT, () => {
+//    console.log(`App is listening on Port ${PORT}`);
+//});
 
 // Demo interval scrape
 //crawlerController.startScrapeInterval('pizza', 10000);


### PR DESCRIPTION
By default, HTTPS is over port 4443, while HTTP is still over port 4000. For example, the user creation page is now available at http://localhost:4000/config or https://localhost:4443/config